### PR TITLE
removed 0.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ env:
   - CXX=g++-4.8
 
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
   - "8"
@@ -22,7 +19,6 @@ sudo: false
 
 before_install:
   - $CXX --version
-  - if [ "$TRAVIS_NODE_VERSION" = "0.8" ]; then npm install -g npm@2.7.3; fi;
 
 install: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: "0.10"
-    platform: x64
-  - nodejs_version: "0.10"
-    platform: x86
-  - nodejs_version: "0.12"
-    platform: x64
-  - nodejs_version: "0.12"
-    platform: x86
   - nodejs_version: "4"
     platform: x64
   - nodejs_version: "4"


### PR DESCRIPTION
Trying to give https://github.com/kelektiv/node.bcrypt.js/pull/511 a bit more visibility, apparently this is the only pending change to make Appveyor go green and merge.

Opening a pull request here as https://github.com/kelektiv/node.bcrypt.js/pull/511 seems a bit abandoned by the people in charge, maybe this will get visibility from HungryUp and we can move forward (I don't want to open a new PR as work by you has been done here).